### PR TITLE
Fixes an issue where the default timestamp was set to 0

### DIFF
--- a/Float.TinCan.ActivityLibrary.Tests/TinCanStatementBuilder.tests.cs
+++ b/Float.TinCan.ActivityLibrary.Tests/TinCanStatementBuilder.tests.cs
@@ -13,5 +13,16 @@ namespace Float.TinCan.ActivityLibrary.Tests
                 .Build();
             Assert.NotNull(statement);
         }
+
+        [Fact]
+        public void TestDefaultStatementTimestamp()
+        {
+            var statement = new TinCanStatementBuilder()
+                .Build();
+
+            // The default timestamp should be (approximately) now.
+            Assert.InRange(statement.timestamp ?? new System.DateTime(), System.DateTime.UtcNow.AddSeconds(-1), System.DateTime.UtcNow);
+            System.Console.WriteLine(statement.ToJSON());
+        }
     }
 }

--- a/Float.TinCan.ActivityLibrary/TinCanStatementBuilder.cs
+++ b/Float.TinCan.ActivityLibrary/TinCanStatementBuilder.cs
@@ -36,7 +36,7 @@ namespace Float.TinCan.ActivityLibrary
         /// <summary>
         /// The timestamp for the statement to be built. Optional.
         /// </summary>
-        DateTime timestamp;
+        DateTime? timestamp;
 
         /// <summary>
         /// Gets the session ID for the statement to be build. Optional.


### PR DESCRIPTION
Since `DateTime` is a value type, we must define it as nullable otherwise it's default value will be 0 (resulting in default timestamps of `0001-01-01T00:00:00.000Z`).